### PR TITLE
Permit external command to process the pandoc before converting

### DIFF
--- a/Yst/Config.hs
+++ b/Yst/Config.hs
@@ -41,6 +41,7 @@ parseConfigFile configfile = do
                     , indexFile     = indexfile
                     , pageIndex     = M.fromList $ map (\pg -> (pageUrl pg, pg)) ind
                     , navigation    = nav
+                    , filterCommand = getStrAttrMaybe "filter" xs
                     }
        _       -> errorExit 7 "Configuration file must be a YAML hash." >> return undefined
 

--- a/Yst/Types.hs
+++ b/Yst/Types.hs
@@ -34,6 +34,7 @@ data Site = Site {
   , indexFile     :: FilePath
   , pageIndex     :: M.Map String Page
   , navigation    :: [NavNode]
+  , filterCommand :: Maybe String
   } deriving (Show, Read, Eq)
 
 data Source = TemplateFile FilePath

--- a/Yst/Util.hs
+++ b/Yst/Util.hs
@@ -16,7 +16,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -}
 
-module Yst.Util (stripBlanks, parseAsDate, stripStExt, getStrAttrWithDefault, getStrListWithDefault, fromNString, getDirectoryContentsRecursive, searchPath, errorExit)
+module Yst.Util (stripBlanks, parseAsDate, stripStExt, getStrAttrMaybe, getStrAttrWithDefault, getStrListWithDefault, fromNString, getDirectoryContentsRecursive, searchPath, errorExit)
 where
 import Yst.Types
 import System.Exit
@@ -52,12 +52,16 @@ stripStExt f =
      then dropExtension f
      else f
 
+getStrAttrMaybe :: String -> [(String, Node)] -> Maybe String
+getStrAttrMaybe attr xs =
+  case lookup attr xs of
+    Just (NString s) -> Just s
+    Just _ -> error $ attr ++ " must have string value."
+    Nothing -> Nothing
+
 getStrAttrWithDefault :: String -> String -> [(String, Node)] -> String
 getStrAttrWithDefault attr def xs =
-  case lookup attr xs of
-        Just (NString s)   -> s
-        Just _             -> error $ attr ++ " must have string value."
-        Nothing            -> def
+  maybe def id $ getStrAttrMaybe attr xs
 
 getStrListWithDefault :: String -> String -> [(String, Node)] -> [String]
 getStrListWithDefault attr def xs =

--- a/demo/config.yaml
+++ b/demo/config.yaml
@@ -4,3 +4,4 @@ sourcedir: [., templates]
 datadir: .
 filesdir: [files, yahoo]
 layout: layout.html.st
+filter: runhaskell includeCode.hs

--- a/demo/includeCode.hs
+++ b/demo/includeCode.hs
@@ -1,0 +1,12 @@
+import Text.Pandoc
+
+main = toJsonFilter includeCodeBlock
+  where includeCodeBlock (cb@(CodeBlock (attr@(_, _, kvs)) _)) =
+          case lookup "include" kvs of
+            Just f -> readFile f >>= return . CodeBlock attr . chopNewline
+            Nothing -> return cb
+        includeCodeBlock b = return b
+
+        chopNewline s = case reverse s of
+            '\n' : rs -> reverse rs
+            _ -> s

--- a/demo/index.st
+++ b/demo/index.st
@@ -14,3 +14,10 @@ yst supports unicode:
 - أنا قادر على أكل الزجاج و هذا لا يؤلمني.
 - 我能吞下玻璃而不伤身体。
 
+
+yst code inclusion:
+
+~~~~ {.haskell include="includeCode.hs"}
+-- This should be a code block
+main = putStrLn "Hello!"
+~~~~

--- a/demo/index.yaml
+++ b/demo/index.yaml
@@ -1,7 +1,7 @@
 - url      : index.html
   title    : Home
   template : index.st
-  requires : event.st
+  requires : [event.st, includeCode.hs]
   data     :
     recentevents : FROM events.yaml ORDER BY date DESC LIMIT 2
 

--- a/yst.cabal
+++ b/yst.cabal
@@ -57,7 +57,7 @@ Executable           yst
   build-depends:     base >=3 && < 5, HStringTemplate >= 0.6.1, HsSyck, csv,
                      filepath, containers, directory, utf8-string, time,
                      old-locale, old-time, parsec, xhtml, pandoc, bytestring,
-                     split, HDBC, HDBC-sqlite3
+                     split, HDBC, HDBC-sqlite3, process, json
   extensions:        CPP
   if impl(ghc >= 6.12)
     ghc-options:     -Wall -threaded -fno-warn-orphans -fno-warn-unused-do-bind

--- a/yst.cabal
+++ b/yst.cabal
@@ -44,6 +44,7 @@ data-files:          README.markdown
                      demo/yahoo/css/reset-min.css
                      demo/files/css/screen.css
                      demo/files/js/nav.js
+                     demo/includeCode.hs
 
 Source-repository    head
   type:              git


### PR DESCRIPTION
This change enables a filter: setting in config.yaml that contains a shell command. If present, the Pandoc AST (in JSON format) will be piped through that command before converting to an output format.

This will enable any of the sorts of transformations presented on the [scripting with pandoc](http://johnmacfarlane.net/pandoc/scripting.html) page.

In the demo/ site, I used it to include a code block from an external file.