### PR TITLE
Prefix js/nav file with $root$ for nested paths

### DIFF
--- a/demo/layout.html.st
+++ b/demo/layout.html.st
@@ -18,7 +18,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"
             type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
-    <script src="js/nav.js" type="text/javascript"></script>
+    <script src="$root$js/nav.js" type="text/javascript"></script>
     <link rel="stylesheet" type="text/css" href="$root$css/screen.css" />
     <link rel="stylesheet" type="text/css" media="print" href="$root$css/print.css" />
   </head>


### PR DESCRIPTION
When using the default layout, nav.js returns a 404 on nested URL's (ie, /<dir>/<somewhere>). Prefixing the nav.js source path with $root$ fixes it.