### PR TITLE
Fix warnings in stack lts-8 build

### DIFF
--- a/Yst/Build.hs
+++ b/Yst/Build.hs
@@ -38,9 +38,19 @@ import System.Time (ClockTime(..))
 -- So we use System.IO.UTF8 only if we have an earlier version
 #if MIN_VERSION_base(4,2,0)
 import System.IO (hPutStrLn)
+#if !(MIN_VERSION_base(4,6,0))
 import Prelude hiding (catch)
+#endif
 #else
-import Prelude hiding (readFile, putStrLn, print, writeFile, catch)
+import Prelude hiding (
+  readFile
+, putStrLn
+, print
+, writeFile
+#if !(MIN_VERSION_base(4,6,0))
+, catch
+#endif
+)
 import System.IO.UTF8
 #endif
 import System.IO (stderr)

--- a/Yst/CSV.hs
+++ b/Yst/CSV.hs
@@ -25,9 +25,16 @@ import Text.CSV
 -- Note: ghc >= 6.12 (base >=4.2) supports unicode through iconv
 -- So we use System.IO.UTF8 only if we have an earlier version
 #if MIN_VERSION_base(4,2,0)
+#if !(MIN_VERSION_base(4,6,0))
 import Prelude hiding (catch)
+#endif
 #else
-import Prelude hiding (readFile, catch)
+import Prelude hiding (
+  readFile
+#if !(MIN_VERSION_base(4,6,0))
+, catch
+#endif
+)
 import System.IO.UTF8
 #endif
 import Control.Exception (catch, SomeException)

--- a/Yst/Render.hs
+++ b/Yst/Render.hs
@@ -85,10 +85,6 @@ renderNavNode targeturl (NavPage tit pageurl) =
 renderNavNode targeturl (NavMenu tit nodes) = li_ [] $
     do a_ [class_ "tree-toggle nav-header"] (toHtml tit)
        ul_ [class_ "nav tree"] (mapM_ (renderNavNode targeturl) nodes)
-    -- where active = targeturl `isInNavNodes` nodes
-    --       isInNavNodes u = any (isInNavNode u)
-    --       isInNavNode u (NavPage _ u') = u == u'
-    --       isInNavNode u (NavMenu _ ns) = u `isInNavNodes` ns
 
 formatFromExtension :: FilePath -> Format
 formatFromExtension f = case (map toLower $ takeExtension f) of

--- a/Yst/Render.hs
+++ b/Yst/Render.hs
@@ -85,10 +85,10 @@ renderNavNode targeturl (NavPage tit pageurl) =
 renderNavNode targeturl (NavMenu tit nodes) = li_ [] $
     do a_ [class_ "tree-toggle nav-header"] (toHtml tit)
        ul_ [class_ "nav tree"] (mapM_ (renderNavNode targeturl) nodes)
-    where active = targeturl `isInNavNodes` nodes
-          isInNavNodes u = any (isInNavNode u)
-          isInNavNode u (NavPage _ u') = u == u'
-          isInNavNode u (NavMenu _ ns) = u `isInNavNodes` ns
+    -- where active = targeturl `isInNavNodes` nodes
+    --       isInNavNodes u = any (isInNavNode u)
+    --       isInNavNode u (NavPage _ u') = u == u'
+    --       isInNavNode u (NavMenu _ ns) = u `isInNavNodes` ns
 
 formatFromExtension :: FilePath -> Format
 formatFromExtension f = case (map toLower $ takeExtension f) of


### PR DESCRIPTION
`catch` was removed from `Prelude` in base-4.6.0.0, so hiding it
causes a warning in some environments.

    /home/travis/build/jgm/yst/Yst/CSV.hs:28:1: warning:
    [-Wdodgy-imports]
    Module ‘Prelude’ does not export ‘catch’

This currently causes Travis CI to fail:
https://travis-ci.org/jgm/yst/jobs/201667249